### PR TITLE
Fix build on case-sensitive filesystem

### DIFF
--- a/JumperlessNano/src/LEDs.cpp
+++ b/JumperlessNano/src/LEDs.cpp
@@ -2,7 +2,7 @@
 #include <Adafruit_NeoPixel.h>
 #include "NetsToChipConnections.h"
 #include "MatrixStateRP2040.h"
-#include "fileParsing.h"
+#include "FileParsing.h"
 
 Adafruit_NeoPixel leds(LED_COUNT, LED_PIN, NEO_GRB + NEO_KHZ800);
 


### PR DESCRIPTION
Otherwise compiling JumperlessNode on Linux fails with:
```
src/LEDs.cpp:5:10: fatal error: fileParsing.h: No such file or directory
```
