### PR TITLE
Add machine commands "getnetlist", "getbridgelist"

### DIFF
--- a/JumperlessNano/src/MachineCommands.h
+++ b/JumperlessNano/src/MachineCommands.h
@@ -1,13 +1,15 @@
 #ifndef MACHINECOMMANDS_H
 #define MACHINECOMMANDS_H
 
-#define NUMBEROFINSTRUCTIONS 13
+#define NUMBEROFINSTRUCTIONS 15
 
 enum machineModeInstruction
 {
     unknown = 0,
     netlist,
+    getnetlist,
     bridgelist,
+    getbridgelist,
     lightnode,
     lightnet,
     getmeasurement,
@@ -37,5 +39,8 @@ void lightUpNodesFromInputBuffer(void);
 void lightUpNetsFromInputBuffer(void);
 
 int setSupplySwitch(void);
+
+void listNetsMachine(void);
+void listBridgesMachine(void);
 
 #endif

--- a/JumperlessNano/src/main.cpp
+++ b/JumperlessNano/src/main.cpp
@@ -206,6 +206,7 @@ skipinput:
     Serial.print("\n\n\rnetlist\n\n\r");
     listSpecialNets();
     listNets();
+
     break;
   case 'b':
     Serial.print("\n\n\rBridge Array\n\r");
@@ -491,6 +492,10 @@ void machineMode(void) // read in commands in machine readable format
     sendAllPathsCore2 = 1;
     break;
 
+  case getnetlist:
+    listNetsMachine();
+    break;
+
   case bridgelist:
     clearAllNTCC();
 
@@ -508,6 +513,10 @@ void machineMode(void) // read in commands in machine readable format
     // showNets();
 
     sendAllPathsCore2 = 1;
+    break;
+
+  case getbridgelist:
+    listBridgesMachine();
     break;
 
   case lightnode:


### PR DESCRIPTION
Add two new machine commands. These ones are used to query info from the Jumperless in a structured way.

- `::getnetlist[]`: prints the netlist in a machine-readable way:
  ```
  ::netlist-begin
  ::net[1,1,GND,true,001c04,false,GND]
  ::net[2,2,5V,true,1c0702,false,+5V]
  ::net[3,3,3V3,true,1c0107,false,+3.3V]
  ::net[4,4,DAC_0,true,231111,false,DAC 0]
  ::net[5,5,DAC_1,true,230913,false,DAC 1]
  ::net[6,6,I_POS,true,232323,false,I Sense +]
  ::net[7,7,I_NEG,true,232323,false,I Sense -]
  ::netlist-end
  ```

- `::getbridgelist[]`: prints the bridge list in the `::bridgelist[...]` format
