### PR TITLE
Machine mode: respond to commands to signal success

### DIFF
--- a/JumperlessNano/src/MachineCommands.h
+++ b/JumperlessNano/src/MachineCommands.h
@@ -24,7 +24,8 @@ enum machineModeInstruction
 extern char inputBuffer[INPUTBUFFERLENGTH];
 extern char machineModeInstructionString[NUMBEROFINSTRUCTIONS][20];
 
-enum machineModeInstruction parseMachineInstructions(void);
+enum machineModeInstruction parseMachineInstructions(int *sequenceNumber);
+void machineModeRespond(int sequenceNumber, bool ok);
 void machineNetlistToNetstruct(void);
 void populateBridgesFromNodes(void);
 int nodeTokenToInt(char *);

--- a/JumperlessNano/src/main.cpp
+++ b/JumperlessNano/src/main.cpp
@@ -475,8 +475,8 @@ skipinput:
 
 void machineMode(void) // read in commands in machine readable format
 {
-  
-  enum machineModeInstruction receivedInstruction = parseMachineInstructions();
+  int sequenceNumber = -1;
+  enum machineModeInstruction receivedInstruction = parseMachineInstructions(&sequenceNumber);
 
   switch (receivedInstruction)
   {
@@ -545,9 +545,13 @@ void machineMode(void) // read in commands in machine readable format
 
   // case gpio:
   //   break;
+
+  case unknown:
+    machineModeRespond(sequenceNumber, false);
+    return;
   }
 
-  
+  machineModeRespond(sequenceNumber, true);
 }
 
 unsigned long logoFlashTimer = 0;


### PR DESCRIPTION
After processing a machine-mode instruction, respond with "::ok\r\n". This way the host side knows if an instruction was processed or not.

Also instructions can carry an optional "sequence number" now, which will be echoed in the "ok" response.

Example: `::lightnode:23[...]` responds with: `::ok:23`

The sequence number can be used on the host side to synchronize specific function calls with their response.

Unknown instructions respond with `::error` instead.