### PR TITLE
Add command 'getchipstatus'

### DIFF
--- a/JumperlessNano/src/MachineCommands.cpp
+++ b/JumperlessNano/src/MachineCommands.cpp
@@ -22,7 +22,7 @@ ArduinoJson::DynamicJsonDocument machineModeJson(8000);
 
 enum machineModeInstruction lastReceivedInstruction = unknown;
 
-char machineModeInstructionString[NUMBEROFINSTRUCTIONS][20] = {"unknown", "netlist", "getnetlist", "bridgelist", "getbridgelist", "lightnode", "lightnet", "getmeasurement", "gpio", "uart", "arduinoflash", "setnetcolor", "setnodecolor", "setsupplyswitch", "getsupplyswitch"};
+char machineModeInstructionString[NUMBEROFINSTRUCTIONS][20] = {"unknown", "netlist", "getnetlist", "bridgelist", "getbridgelist", "lightnode", "lightnet", "getmeasurement", "gpio", "uart", "arduinoflash", "setnetcolor", "setnodecolor", "setsupplyswitch", "getsupplyswitch", "getchipstatus"};
 
 enum machineModeInstruction parseMachineInstructions(int *sequenceNumber)
 {
@@ -809,4 +809,25 @@ void listBridgesMachine(void)
         }
     }
     Serial.println("]");
+}
+
+void printChipStatusMachine() {
+  Serial.println("::chipstatus-begin");
+  for (int i = 0; i < 12; i++) {
+    Serial.print("::chipstatus[");
+    Serial.print(chipNumToChar(i));
+    Serial.print(",");
+    for (int j = 0; j < 16; j++) {
+      Serial.print(ch[i].xStatus[j]);
+      Serial.print(",");
+    }
+    for (int j = 0; j < 8; j++) {
+      Serial.print(ch[i].yStatus[j]);
+      if (j != 7) {
+        Serial.print(",");
+      }
+    }
+    Serial.println("]");
+  }
+  Serial.println("::chipstatus-end");
 }

--- a/JumperlessNano/src/MachineCommands.h
+++ b/JumperlessNano/src/MachineCommands.h
@@ -2,7 +2,7 @@
 #ifndef MACHINECOMMANDS_H
 #define MACHINECOMMANDS_H
 
-#define NUMBEROFINSTRUCTIONS 16
+#define NUMBEROFINSTRUCTIONS 17
 
 enum machineModeInstruction
 {
@@ -20,7 +20,8 @@ enum machineModeInstruction
     setnetcolor,
     setnodecolor,
     setsupplyswitch,
-    getsupplyswitch
+    getsupplyswitch,
+    getchipstatus
 };
 
 extern char inputBuffer[INPUTBUFFERLENGTH];
@@ -47,5 +48,7 @@ int setSupplySwitch(void);
 
 void listNetsMachine(void);
 void listBridgesMachine(void);
+
+void printChipStatusMachine();
 
 #endif

--- a/JumperlessNano/src/main.cpp
+++ b/JumperlessNano/src/main.cpp
@@ -705,6 +705,10 @@ if (millis() - lastTimeCommandRecieved > 100)
   }
     break;
 
+  case getchipstatus:
+    printChipStatusMachine();
+    break;
+
     // case gpio:
     //   break;
 


### PR DESCRIPTION
Added `getchipstatus` command, to print the chip status arrays in a parsable way.

I'm not quite sure yet what to do with that info on the UI side, but some kind of feedback what's connected with what through which chip will surely be useful.